### PR TITLE
Change css to scss

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,4 +14,5 @@
  *= require_self
  */
 
- *= require font-awesome
+ @import 'blogs';
+ @import 'font-awesome';


### PR DESCRIPTION
# What
cssファイルをscssに変更した。

# Why
herokuへのデプロイ中にエラーが出たため。
Sass::SyntaxError: Invalid CSS after "...re font-awesome": expected "{", was ""
とあったので{が多いところ無いか確認したが見当たらなかったため、cssをscssに変更。